### PR TITLE
fix: add native libraries for Electron/BrowserView support

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -6,6 +6,28 @@
   makeWrapper,
   undmg,
   google-chrome,
+  # Additional libraries for Electron/webview support
+  libxkbfile,
+  libsecret,
+  libGL,
+  libdrm,
+  mesa,
+  nss,
+  nspr,
+  at-spi2-atk,
+  at-spi2-core,
+  libxkbcommon,
+  xorg,
+  wayland,
+  gtk3,
+  glib,
+  pango,
+  cairo,
+  gdk-pixbuf,
+  libnotify,
+  cups,
+  libpulseaudio,
+  systemd,
 }:
 
 let
@@ -43,9 +65,45 @@ if stdenv.hostPlatform.isLinux then
     inherit pname version;
     src = source;
 
-    # Include Chrome in the FHS environment for Browser Automation
+    # Include Chrome and essential Electron/webview libraries in FHS environment
     extraPkgs = pkgs: [
       google-chrome
+      # Keyboard/input handling (fixes native-keymap errors)
+      libxkbfile
+      libxkbcommon
+      xorg.libxkbfile
+      # Security/credentials
+      libsecret
+      nss
+      nspr
+      # Graphics/GPU
+      libGL
+      libdrm
+      mesa
+      # GTK/display
+      gtk3
+      glib
+      pango
+      cairo
+      gdk-pixbuf
+      # Accessibility (needed for BrowserView)
+      at-spi2-atk
+      at-spi2-core
+      # Wayland support
+      wayland
+      # System integration
+      libnotify
+      cups
+      libpulseaudio
+      systemd
+      # X11 libraries
+      xorg.libX11
+      xorg.libXcomposite
+      xorg.libXdamage
+      xorg.libXext
+      xorg.libXfixes
+      xorg.libXrandr
+      xorg.libxcb
     ];
 
     # Ensure Chrome is accessible with standard names


### PR DESCRIPTION
## Summary

Adds missing system libraries to `extraPkgs` in the AppImage wrapper to fix native module loading issues on NixOS.

## Problem

Without these libraries, Cursor fails with multiple errors:

```
Error: Cannot find module './build/Debug/keymapping'
TypeError: Cannot read properties of null (reading 'getCurrentKeyboardLayout')
TypeError: Cannot read properties of null (reading 'onDidChangeKeyboardLayout')
[BrowserViewMainService] Cannot execute JavaScript: browser view not created for window 1
```

## Solution

Add the following libraries to the FHS environment:

| Category | Libraries |
|----------|-----------|
| Keyboard/input | `libxkbfile`, `libxkbcommon` |
| Security/credentials | `libsecret`, `nss`, `nspr` |
| Graphics/GPU | `libGL`, `libdrm`, `mesa` |
| GTK/display | `gtk3`, `glib`, `pango`, `cairo`, `gdk-pixbuf` |
| Accessibility | `at-spi2-atk`, `at-spi2-core` |
| Wayland | `wayland` |
| System integration | `libnotify`, `cups`, `libpulseaudio`, `systemd` |
| X11 | `libX11`, `libXcomposite`, `libXdamage`, `libXext`, `libXfixes`, `libXrandr`, `libxcb` |

## Testing

- Tested on NixOS with Cursor 2.2.43
- All `native-keymap` errors resolved
- Native modules load successfully: `[CursorProclistService] Native module loaded successfully`
- Cursor runs stable with no recurring errors

## Before/After

**Before (vanilla 2.2.43):**
```
Error: Cannot find module './build/Debug/keymapping'
TypeError: Cannot read properties of null (reading 'getCurrentKeyboardLayout')
```

**After (with this fix):**
```
[CursorProclistService] Native module loaded successfully
update#setState idle
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)