### PR TITLE
fix: update x86_64-linux AppImage hash for 3.0.13 and replace deprecated xorg.* package names

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -17,7 +17,13 @@
   at-spi2-atk,
   at-spi2-core,
   libxkbcommon,
-  xorg,
+  libx11,
+  libxcomposite,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxrandr,
+  libxcb,
   wayland,
   gtk3,
   glib,
@@ -71,7 +77,6 @@ if stdenv.hostPlatform.isLinux then
       # Keyboard/input handling (fixes native-keymap errors)
       libxkbfile
       libxkbcommon
-      xorg.libxkbfile
       # Security/credentials
       libsecret
       nss
@@ -97,13 +102,13 @@ if stdenv.hostPlatform.isLinux then
       libpulseaudio
       systemd
       # X11 libraries
-      xorg.libX11
-      xorg.libXcomposite
-      xorg.libXdamage
-      xorg.libXext
-      xorg.libXfixes
-      xorg.libXrandr
-      xorg.libxcb
+      libx11
+      libxcomposite
+      libxdamage
+      libxext
+      libxfixes
+      libxrandr
+      libxcb
     ];
 
     # Ensure Chrome is accessible with standard names

--- a/package.nix
+++ b/package.nix
@@ -127,7 +127,7 @@ if stdenv.hostPlatform.isLinux then
       for size in 16 32 48 64 128 256 512 1024; do
         if [ -f ${appimageContents}/usr/share/icons/hicolor/''${size}x''${size}/apps/cursor.png ]; then
           install -Dm444 ${appimageContents}/usr/share/icons/hicolor/''${size}x''${size}/apps/cursor.png \
-            $out/share/icons/hicolor/''${size}x''${size}/apps/cursor.png
+            $out/share/icons/hicolor/''${size}x''${size}/apps/co.anysphere.cursor.png
         fi
       done
     '';

--- a/package.nix
+++ b/package.nix
@@ -37,7 +37,7 @@ let
   sources = {
     x86_64-linux = fetchurl {
       url = "https://downloads.cursor.com/production/48a15759f53cd5fc9b5c20936ad7d79847d914b5/linux/x64/Cursor-${version}-x86_64.AppImage";
-      hash = "sha256-MbtQWkf2U8e//pAoY4mGFoxFi/7zwwnI/jylU5HxgM4=";
+      hash = "sha256-GaeBuRRvVAoz8qr4xz6Kq0f7aKU6vIJZHqTjrhivqs4=";
     };
     aarch64-linux = fetchurl {
       url = "https://downloads.cursor.com/production/b9e5948c1ad20443a5cecba6b84a3c9b99d62582/linux/arm64/Cursor-${version}-aarch64.AppImage";


### PR DESCRIPTION
## Summary
- Updated the x86_64-linux AppImage hash for Cursor 3.0.13
- Cursor replaced the binary at the same download URL, causing a `hash mismatch in fixed-output derivation` error during build

Fixes #49