### PR TITLE
fix: replace deprecated xorg.* package names with top-level equivalents

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -17,7 +17,13 @@
   at-spi2-atk,
   at-spi2-core,
   libxkbcommon,
-  xorg,
+  libx11,
+  libxcomposite,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxrandr,
+  libxcb,
   wayland,
   gtk3,
   glib,
@@ -71,7 +77,6 @@ if stdenv.hostPlatform.isLinux then
       # Keyboard/input handling (fixes native-keymap errors)
       libxkbfile
       libxkbcommon
-      xorg.libxkbfile
       # Security/credentials
       libsecret
       nss
@@ -97,13 +102,13 @@ if stdenv.hostPlatform.isLinux then
       libpulseaudio
       systemd
       # X11 libraries
-      xorg.libX11
-      xorg.libXcomposite
-      xorg.libXdamage
-      xorg.libXext
-      xorg.libXfixes
-      xorg.libXrandr
-      xorg.libxcb
+      libx11
+      libxcomposite
+      libxdamage
+      libxext
+      libxfixes
+      libxrandr
+      libxcb
     ];
 
     # Ensure Chrome is accessible with standard names
@@ -122,7 +127,7 @@ if stdenv.hostPlatform.isLinux then
       for size in 16 32 48 64 128 256 512 1024; do
         if [ -f ${appimageContents}/usr/share/icons/hicolor/''${size}x''${size}/apps/cursor.png ]; then
           install -Dm444 ${appimageContents}/usr/share/icons/hicolor/''${size}x''${size}/apps/cursor.png \
-            $out/share/icons/hicolor/''${size}x''${size}/apps/cursor.png
+            $out/share/icons/hicolor/''${size}x''${size}/apps/co.anysphere.cursor.png
         fi
       done
     '';


### PR DESCRIPTION
## Summary

This PR replaces all deprecated `xorg.*` attribute paths with their renamed top-level equivalents in nixpkgs, eliminating the evaluation warnings:

```
evaluation warning: The xorg package set has been deprecated, 'xorg.libX11' has been renamed to 'libx11'
...
```

### Changes
- `xorg.libX11` → `libx11`
- `xorg.libXcomposite` → `libxcomposite`
- `xorg.libXdamage` → `libxdamage`
- `xorg.libXext` → `libxext`
- `xorg.libXfixes` → `libxfixes`
- `xorg.libXrandr` → `libxrandr`
- `xorg.libxcb` → `libxcb`
- Remove duplicate `xorg.libxkbfile` (top-level `libxkbfile` was already listed)
- Rename icon install path to `co.anysphere.cursor.png` to match the desktop file entry

This is the same fix proposed in #50, rebased cleanly on top of the current `main` (3.0.16), resolving the merge conflict that blocked that PR.