### PR TITLE
fix: align icon filename with cursor.desktop and drop deprecated xorg.*

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -17,7 +17,13 @@
   at-spi2-atk,
   at-spi2-core,
   libxkbcommon,
-  xorg,
+  libx11,
+  libxcomposite,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxrandr,
+  libxcb,
   wayland,
   gtk3,
   glib,
@@ -71,7 +77,6 @@ if stdenv.hostPlatform.isLinux then
       # Keyboard/input handling (fixes native-keymap errors)
       libxkbfile
       libxkbcommon
-      xorg.libxkbfile
       # Security/credentials
       libsecret
       nss
@@ -97,13 +102,13 @@ if stdenv.hostPlatform.isLinux then
       libpulseaudio
       systemd
       # X11 libraries
-      xorg.libX11
-      xorg.libXcomposite
-      xorg.libXdamage
-      xorg.libXext
-      xorg.libXfixes
-      xorg.libXrandr
-      xorg.libxcb
+      libx11
+      libxcomposite
+      libxdamage
+      libxext
+      libxfixes
+      libxrandr
+      libxcb
     ];
 
     # Ensure Chrome is accessible with standard names
@@ -119,10 +124,12 @@ if stdenv.hostPlatform.isLinux then
         --replace-fail 'Exec=cursor' 'Exec=${pname}'
 
       # Copy icon files
+      # cursor.desktop references Icon=co.anysphere.cursor — rename on install so
+      # desktop environments can resolve the icon (AppImage ships it as cursor.png).
       for size in 16 32 48 64 128 256 512 1024; do
         if [ -f ${appimageContents}/usr/share/icons/hicolor/''${size}x''${size}/apps/cursor.png ]; then
           install -Dm444 ${appimageContents}/usr/share/icons/hicolor/''${size}x''${size}/apps/cursor.png \
-            $out/share/icons/hicolor/''${size}x''${size}/apps/cursor.png
+            $out/share/icons/hicolor/''${size}x''${size}/apps/co.anysphere.cursor.png
         fi
       done
     '';


### PR DESCRIPTION
## Summary
- Rename installed icon from `cursor.png` to `co.anysphere.cursor.png` to match the `Icon=co.anysphere.cursor` field shipped in `cursor.desktop` — desktop launchers can now resolve the icon
- Replace `xorg.libX11` and siblings with their top-level equivalents (`libx11`, `libxcomposite`, `libxdamage`, `libxext`, `libxfixes`, `libxrandr`, `libxcb`) — silences 12 deprecation warnings emitted by current nixpkgs
- Drop the redundant `xorg.libxkbfile` line (`libxkbfile` was already listed)

## Background
Both changes originate from #50 by @max-miller1204, which was closed after being superseded by direct hash refreshes on `main` (3.0.13 → 3.0.16 → 3.1.x → 3.2.x → 3.3.30). Reapplied here against current `main` with credit preserved as a co-author on the commit.

## Verification
- [x] `nix flake check` — passes with zero deprecation warnings (was 12)
- [x] `nix build .#cursor` — succeeds against 3.3.30
- [x] `result/share/icons/hicolor/*/apps/co.anysphere.cursor.png` exists in build output
- [x] `cursor.desktop` in 3.3.30 still references `Icon=co.anysphere.cursor`

## Test plan
- [ ] Launch Cursor from a desktop launcher and confirm the icon now displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)